### PR TITLE
Add Framework Target

### DIFF
--- a/BUYPaymentButton.xcodeproj/project.pbxproj
+++ b/BUYPaymentButton.xcodeproj/project.pbxproj
@@ -1,0 +1,295 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		4E5280E51B5ED4D10013F2B8 /* BUYPaymentButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 4E5280E41B5ED4D10013F2B8 /* BUYPaymentButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4E5281221B5ED5900013F2B8 /* BUYPaymentButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E5281211B5ED5900013F2B8 /* BUYPaymentButton.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		4E5280DF1B5ED4D10013F2B8 /* BUYPaymentButton.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BUYPaymentButton.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E5280E31B5ED4D10013F2B8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4E5280E41B5ED4D10013F2B8 /* BUYPaymentButton.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BUYPaymentButton.h; sourceTree = "<group>"; };
+		4E5281211B5ED5900013F2B8 /* BUYPaymentButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BUYPaymentButton.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4E5280DB1B5ED4D10013F2B8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4E5280D51B5ED4D10013F2B8 = {
+			isa = PBXGroup;
+			children = (
+				4E5280E11B5ED4D10013F2B8 /* BUYPaymentButton */,
+				4E5280E01B5ED4D10013F2B8 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		4E5280E01B5ED4D10013F2B8 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4E5280DF1B5ED4D10013F2B8 /* BUYPaymentButton.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4E5280E11B5ED4D10013F2B8 /* BUYPaymentButton */ = {
+			isa = PBXGroup;
+			children = (
+				4E5280E41B5ED4D10013F2B8 /* BUYPaymentButton.h */,
+				4E5281211B5ED5900013F2B8 /* BUYPaymentButton.m */,
+				4E5280E21B5ED4D10013F2B8 /* Supporting Files */,
+			);
+			path = BUYPaymentButton;
+			sourceTree = "<group>";
+		};
+		4E5280E21B5ED4D10013F2B8 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4E5280E31B5ED4D10013F2B8 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		4E5280DC1B5ED4D10013F2B8 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E5280E51B5ED4D10013F2B8 /* BUYPaymentButton.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		4E5280DE1B5ED4D10013F2B8 /* BUYPaymentButton */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E5280F51B5ED4D10013F2B8 /* Build configuration list for PBXNativeTarget "BUYPaymentButton" */;
+			buildPhases = (
+				4E5280DA1B5ED4D10013F2B8 /* Sources */,
+				4E5280DB1B5ED4D10013F2B8 /* Frameworks */,
+				4E5280DC1B5ED4D10013F2B8 /* Headers */,
+				4E5280DD1B5ED4D10013F2B8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BUYPaymentButton;
+			productName = BUYPaymentButton;
+			productReference = 4E5280DF1B5ED4D10013F2B8 /* BUYPaymentButton.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4E5280D61B5ED4D10013F2B8 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0640;
+				ORGANIZATIONNAME = Shopify;
+				TargetAttributes = {
+					4E5280DE1B5ED4D10013F2B8 = {
+						CreatedOnToolsVersion = 6.4;
+					};
+				};
+			};
+			buildConfigurationList = 4E5280D91B5ED4D10013F2B8 /* Build configuration list for PBXProject "BUYPaymentButton" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4E5280D51B5ED4D10013F2B8;
+			productRefGroup = 4E5280E01B5ED4D10013F2B8 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4E5280DE1B5ED4D10013F2B8 /* BUYPaymentButton */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4E5280DD1B5ED4D10013F2B8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4E5280DA1B5ED4D10013F2B8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4E5281221B5ED5900013F2B8 /* BUYPaymentButton.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		4E5280F31B5ED4D10013F2B8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4E5280F41B5ED4D10013F2B8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		4E5280F61B5ED4D10013F2B8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BUYPaymentButton/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "-DBUYFRAMEWORK_TARGET=1";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4E5280F71B5ED4D10013F2B8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BUYPaymentButton/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_CFLAGS = "-DBUYFRAMEWORK_TARGET=1";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4E5280D91B5ED4D10013F2B8 /* Build configuration list for PBXProject "BUYPaymentButton" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E5280F31B5ED4D10013F2B8 /* Debug */,
+				4E5280F41B5ED4D10013F2B8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4E5280F51B5ED4D10013F2B8 /* Build configuration list for PBXNativeTarget "BUYPaymentButton" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4E5280F61B5ED4D10013F2B8 /* Debug */,
+				4E5280F71B5ED4D10013F2B8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4E5280D61B5ED4D10013F2B8 /* Project object */;
+}

--- a/BUYPaymentButton.xcodeproj/xcshareddata/xcschemes/BUYPaymentButton.xcscheme
+++ b/BUYPaymentButton.xcodeproj/xcshareddata/xcschemes/BUYPaymentButton.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E5280DE1B5ED4D10013F2B8"
+               BuildableName = "BUYPaymentButton.framework"
+               BlueprintName = "BUYPaymentButton"
+               ReferencedContainer = "container:BUYPaymentButton.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E5280DE1B5ED4D10013F2B8"
+            BuildableName = "BUYPaymentButton.framework"
+            BlueprintName = "BUYPaymentButton"
+            ReferencedContainer = "container:BUYPaymentButton.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E5280DE1B5ED4D10013F2B8"
+            BuildableName = "BUYPaymentButton.framework"
+            BlueprintName = "BUYPaymentButton"
+            ReferencedContainer = "container:BUYPaymentButton.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4E5280DE1B5ED4D10013F2B8"
+            BuildableName = "BUYPaymentButton.framework"
+            BlueprintName = "BUYPaymentButton"
+            ReferencedContainer = "container:BUYPaymentButton.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/BUYPaymentButton/BUYPaymentButton.h
+++ b/BUYPaymentButton/BUYPaymentButton.h
@@ -6,6 +6,13 @@
 //  Copyright (c) 2015 Shopify Inc. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
+
+#if defined(BUYFRAMEWORK_TARGET) && BUYFRAMEWORK_TARGET
+FOUNDATION_EXPORT double BUYPaymentButtonVersionNumber;
+FOUNDATION_EXPORT const unsigned char BUYPaymentButtonVersionString[];
+#endif
+
 typedef NS_ENUM(NSInteger, BUYPaymentButtonStyle) {
     BUYPaymentButtonStyleWhite = 0,
     BUYPaymentButtonStyleWhiteOutline,

--- a/BUYPaymentButton/BUYPaymentButton.h
+++ b/BUYPaymentButton/BUYPaymentButton.h
@@ -7,6 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <PassKit/PassKit.h>
 
 #if defined(BUYFRAMEWORK_TARGET) && BUYFRAMEWORK_TARGET
 FOUNDATION_EXPORT double BUYPaymentButtonVersionNumber;

--- a/BUYPaymentButton/BUYPaymentButton.m
+++ b/BUYPaymentButton/BUYPaymentButton.m
@@ -6,7 +6,6 @@
 //  Copyright (c) 2015 Shopify Inc. All rights reserved.
 //
 
-@import PassKit;
 #import "BUYPaymentButton.h"
 
 @interface BUYCustomPaymentButton : UIButton

--- a/BUYPaymentButton/Info.plist
+++ b/BUYPaymentButton/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.shopify.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds an iOS framework target (and required Xcode Project). This allows the library to be used by tools such as Carthage for dependency management.
